### PR TITLE
Update actions/checkout to v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build
       run: npx --package mini-cross@0.15.2 mc --no-tty cli make clean build


### PR DESCRIPTION
Will avoid GitHub Actions warnings.